### PR TITLE
Changed MouseClickListener.java to MouseReleaseListener.java

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .settings/
 bin/
 .project
+.idea/
+*.iml

--- a/JMines.iml
+++ b/JMines.iml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/src/idh/java/jmines/ui/gui/JMinesGui.java
+++ b/src/idh/java/jmines/ui/gui/JMinesGui.java
@@ -23,7 +23,7 @@ import idh.java.jmines.model.GameState;
 import idh.java.jmines.ui.JMinesUi;
 import idh.java.jmines.ui.UiCallback;
 
-public class JMinesGui extends JFrame implements JMinesUi, ActionListener, MouseClickListener {
+public class JMinesGui extends JFrame implements JMinesUi, ActionListener, MouseReleaseListener {
 	
 	private static final long serialVersionUID = 1L;
 	
@@ -178,7 +178,7 @@ public class JMinesGui extends JFrame implements JMinesUi, ActionListener, Mouse
 	 * registriert haben (hier: die Cell-Buttons des Spielfelds).
 	 */
 	@Override
-	public void mouseClicked(MouseEvent e) {
+	public void mouseReleased(MouseEvent e) {
 		//handelt es sich um einen Linksklick?
 		boolean leftClick = e.getButton() == MouseEvent.BUTTON1;
 		

--- a/src/idh/java/jmines/ui/gui/JMinesGui.java
+++ b/src/idh/java/jmines/ui/gui/JMinesGui.java
@@ -23,7 +23,7 @@ import idh.java.jmines.model.GameState;
 import idh.java.jmines.ui.JMinesUi;
 import idh.java.jmines.ui.UiCallback;
 
-public class JMinesGui extends JFrame implements JMinesUi, ActionListener, MouseReleaseListener {
+public class JMinesGui extends JFrame implements JMinesUi, ActionListener, RightClickListener {
 	
 	private static final long serialVersionUID = 1L;
 	
@@ -119,7 +119,9 @@ public class JMinesGui extends JFrame implements JMinesUi, ActionListener, Mouse
 				// CellButton-Instanz erzeugen (Anzahl angrenzender Minen übergeben)
 				CellButton button = new CellButton(state.getBoard()[x][y]);
 				button.setName("cell-" + x + ":" + y); // "Name" des Buttons (den merkt er sich)
-				button.addMouseListener(this); //MouseListener für Reaktion auf Klick
+				button.addMouseListener(this); //MouseListener für Reaktion auf Rechtsklick
+				button.addActionListener(this); //ActionListener für Reaktion auf Button-Aktin (Links-Klick)
+				button.setActionCommand("reveal"); //Action-Command für Button-Aktion (Links-Klick)
 				//Button dem Panel hinzufügen
 				boardPanel.add(button);
 			}
@@ -167,6 +169,14 @@ public class JMinesGui extends JFrame implements JMinesUi, ActionListener, Mouse
 		case "quit":
 			System.exit(0);
 			break;
+		case "reveal":
+			if (e.getSource() instanceof CellButton) {
+				CellButton cell = ((CellButton)e.getSource());
+				String[] xy = cell.getName().replaceAll("^cell-", "").split("\\:");
+				int x = Integer.parseInt(xy[0]);
+				int y = Integer.parseInt(xy[1]);
+				draw(gameCore.callReveal(x, y)); // bei Linksklick aufdecken
+			}
 		default:
 			break;
 		}
@@ -178,20 +188,13 @@ public class JMinesGui extends JFrame implements JMinesUi, ActionListener, Mouse
 	 * registriert haben (hier: die Cell-Buttons des Spielfelds).
 	 */
 	@Override
-	public void mouseReleased(MouseEvent e) {
-		//handelt es sich um einen Linksklick?
-		boolean leftClick = e.getButton() == MouseEvent.BUTTON1;
-		
-		if (e.getComponent().getName().startsWith("cell-")) {
+	public void mousePressed(MouseEvent e) {
+		if (e.getButton() != MouseEvent.BUTTON1
+				&& e.getComponent().getName().startsWith("cell-")) {
 			String[] xy = e.getComponent().getName().replaceAll("^cell-", "").split("\\:");
 			int x = Integer.parseInt(xy[0]);
 			int y = Integer.parseInt(xy[1]);
-			
-			if (leftClick) {
-				draw(gameCore.callReveal(x, y)); // bei Linksklick aufdecken
-			} else {
-				draw(gameCore.callMark(x, y)); // in allen anderen Fällen markieren
-			}
+			draw(gameCore.callMark(x, y)); // mark cell
 		}
 	}
 	

--- a/src/idh/java/jmines/ui/gui/MouseReleaseListener.java
+++ b/src/idh/java/jmines/ui/gui/MouseReleaseListener.java
@@ -8,9 +8,12 @@ import java.awt.event.MouseListener;
  * herkömmlichen MouseListener zu vereinfachen (wir brauchen nämlich
  * nur eine der fünf Methoden).
  */
-public interface MouseClickListener extends MouseListener {
-	
-	public void mouseClicked(MouseEvent e);
+public interface MouseReleaseListener extends MouseListener {
+
+	@Override
+	default void mouseClicked(MouseEvent e) {
+		// leer
+	}
 	
 	@Override
 	default void mouseEntered(MouseEvent e) {
@@ -28,8 +31,6 @@ public interface MouseClickListener extends MouseListener {
 	}
 	
 	@Override
-	default void mouseReleased(MouseEvent e) {
-		// leer
-	}
+	public void mouseReleased(MouseEvent e);
 
 }

--- a/src/idh/java/jmines/ui/gui/RightClickListener.java
+++ b/src/idh/java/jmines/ui/gui/RightClickListener.java
@@ -8,29 +8,21 @@ import java.awt.event.MouseListener;
  * herkömmlichen MouseListener zu vereinfachen (wir brauchen nämlich
  * nur eine der fünf Methoden).
  */
-public interface MouseReleaseListener extends MouseListener {
+public interface RightClickListener extends MouseListener {
 
 	@Override
-	default void mouseClicked(MouseEvent e) {
-		// leer
-	}
+	default void mouseClicked(MouseEvent e) {}
 	
 	@Override
-	default void mouseEntered(MouseEvent e) {
-		// leer
-	}
+	default void mouseEntered(MouseEvent e) {}
 	
 	@Override
-	default void mouseExited(MouseEvent e) {
-		// leer
-	}
+	default void mouseExited(MouseEvent e) {}
 	
 	@Override
-	default void mousePressed(MouseEvent e) {
-		// leer
-	}
+	public void mousePressed(MouseEvent e);
 	
 	@Override
-	public void mouseReleased(MouseEvent e);
+	default void mouseReleased(MouseEvent e) {}
 
 }


### PR DESCRIPTION
Clicks weren't always registering correctly, due to the MouseEvent only recognizing quick press & release actions as mouseClicks. Longer presses are not classified as clicks. 
By using mouseReleased you only check for the mouse button getting released, which is more reliable in this case.

Includes refactoring of the Interface for better readability/transparency.